### PR TITLE
Remove required from review prompt text

### DIFF
--- a/client/public/locales/en/reviewPopUp.json
+++ b/client/public/locales/en/reviewPopUp.json
@@ -1,6 +1,6 @@
 {
   "leaveAReviewTitle": "Leave a review about our product",
-  "writeShortReview": "Write review*",
+  "writeShortReview": "Write review",
   "writeShortReviewPlaceholder": "Product review",
   "rateTheProduct": "Rate the product*",
   "yourName": "Your name"

--- a/client/public/locales/ua/reviewPopUp.json
+++ b/client/public/locales/ua/reviewPopUp.json
@@ -1,6 +1,6 @@
 {
   "leaveAReviewTitle": "Залиште відгук про наш товар",
-  "writeShortReview": "Напишіть відгук*",
+  "writeShortReview": "Напишіть відгук",
   "writeShortReviewPlaceholder": "Відгук про товар",
   "rateTheProduct": "Оцініть товар*",
   "yourName": "Ваше ім'я"


### PR DESCRIPTION
Eliminate the asterisk from the review prompt text in both English and Ukrainian locales to clarify that the review is not mandatory.